### PR TITLE
Пришвидшення роботи зі станом завдань

### DIFF
--- a/bot/src/main/java/com/community/tools/Application.java
+++ b/bot/src/main/java/com/community/tools/Application.java
@@ -42,12 +42,4 @@ public class Application {
     properties.putAll(prop);
     return properties;
   }
-
-  @Bean("eventHandlers")
-  @Profile("discord")
-  private static List<GithubEventHandler> githubHookEventHandlers() {
-    List<GithubEventHandler> githubEventHandlers = new ArrayList<>();
-    githubEventHandlers.add(new GithubWorkflowRunEventHandler());
-    return githubEventHandlers;
-  }
 }

--- a/bot/src/main/java/com/community/tools/Application.java
+++ b/bot/src/main/java/com/community/tools/Application.java
@@ -1,10 +1,16 @@
 package com.community.tools;
 
+import com.community.tools.service.github.event.GithubEventHandler;
+import com.community.tools.service.github.event.stats.GithubWorkflowRunEventHandler;
 import com.community.tools.util.IoUtils;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
@@ -37,4 +43,11 @@ public class Application {
     return properties;
   }
 
+  @Bean("eventHandlers")
+  @Profile("discord")
+  private static List<GithubEventHandler> githubHookEventHandlers() {
+    List<GithubEventHandler> githubEventHandlers = new ArrayList<>();
+    githubEventHandlers.add(new GithubWorkflowRunEventHandler());
+    return githubEventHandlers;
+  }
 }

--- a/bot/src/main/java/com/community/tools/Application.java
+++ b/bot/src/main/java/com/community/tools/Application.java
@@ -1,16 +1,10 @@
 package com.community.tools;
 
-import com.community.tools.service.github.event.GithubEventHandler;
-import com.community.tools.service.github.event.stats.GithubWorkflowRunEventHandler;
 import com.community.tools.util.IoUtils;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling

--- a/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
+++ b/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
@@ -1,0 +1,25 @@
+package com.community.tools.config;
+
+import com.community.tools.service.github.event.GithubEventHandler;
+import com.community.tools.service.github.event.stats.GithubWorkflowRunEventHandler;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@RequiredArgsConstructor
+public class GithubHookHandlerConfiguration {
+
+  private final GithubWorkflowRunEventHandler githubWorkflowRunEventHandler;
+
+  @Bean("eventHandlers")
+  @Profile("discord")
+  public List<GithubEventHandler> githubHookEventHandlers() {
+    List<GithubEventHandler> githubEventHandlers = new ArrayList<>();
+    githubEventHandlers.add(githubWorkflowRunEventHandler);
+    return githubEventHandlers;
+  }
+}

--- a/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
+++ b/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
@@ -11,10 +11,15 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile("discord")
 public class GithubHookHandlerConfiguration {
 
   private final GithubWorkflowRunEventHandler githubWorkflowRunEventHandler;
 
+  /**
+   * Creates a bean with a list of webhook handlers to be invoked in no specific order upon
+   * receiving an event from GitHub webhook.
+   */
   @Bean("eventHandlers")
   @Profile("discord")
   public List<GithubEventHandler> githubHookEventHandlers() {

--- a/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
+++ b/bot/src/main/java/com/community/tools/config/GithubHookHandlerConfiguration.java
@@ -1,20 +1,38 @@
 package com.community.tools.config;
 
+import com.community.tools.dto.UserForTaskStatusDto;
+import com.community.tools.model.stats.UserTask;
+import com.community.tools.repository.stats.UserTaskRepository;
+import com.community.tools.service.TaskStatusService;
 import com.community.tools.service.github.event.GithubEventHandler;
 import com.community.tools.service.github.event.stats.GithubWorkflowRunEventHandler;
+import java.time.Period;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@RequiredArgsConstructor
 @Profile("discord")
 public class GithubHookHandlerConfiguration {
 
   private final GithubWorkflowRunEventHandler githubWorkflowRunEventHandler;
+  private final TaskStatusService taskStatusServiceRest;
+  private final UserTaskRepository userTaskRepository;
+
+  GithubHookHandlerConfiguration(GithubWorkflowRunEventHandler githubWorkflowRunEventHandler,
+      @Qualifier("taskStatusServiceRest") TaskStatusService taskStatusServiceRest,
+      UserTaskRepository userTaskRepository) {
+    this.githubWorkflowRunEventHandler = githubWorkflowRunEventHandler;
+    this.taskStatusServiceRest = taskStatusServiceRest;
+    this.userTaskRepository = userTaskRepository;
+  }
 
   /**
    * Creates a bean with a list of webhook handlers to be invoked in no specific order upon
@@ -26,5 +44,52 @@ public class GithubHookHandlerConfiguration {
     List<GithubEventHandler> githubEventHandlers = new ArrayList<>();
     githubEventHandlers.add(githubWorkflowRunEventHandler);
     return githubEventHandlers;
+  }
+
+  /**
+   * Creates a CommandLineRunner bean that executes at application startup and attempts to populate
+   * and update user_tasks db table with relevant data proactively, without waiting for GitHub hook
+   * events, exists to avoid generating empty stats tables before receiving any relevant events.
+   */
+  @Bean
+  @Profile("discord")
+  public CommandLineRunner statsTableInitializer() {
+    return new StatsTableInitializer(taskStatusServiceRest, userTaskRepository);
+  }
+
+  @Slf4j
+  public static class StatsTableInitializer implements CommandLineRunner {
+
+    private final TaskStatusService taskStatusServiceRest;
+    private final UserTaskRepository userTaskRepository;
+    @Value("${defaultNumberOfDaysForStatistic}")
+    private Integer defaultNumberOfDays;
+    @Value("${defaultRowLimit}")
+    private Integer defaultUserLimit;
+
+    public StatsTableInitializer(TaskStatusService taskStatusServiceRest,
+        UserTaskRepository userTaskRepository) {
+      this.taskStatusServiceRest = taskStatusServiceRest;
+      this.userTaskRepository = userTaskRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+      log.info("Attempting to initialize user task stats using calls to GitHub REST api");
+      List<UserForTaskStatusDto> userForTaskStatusDtos = taskStatusServiceRest.getTaskStatuses(
+          Period.of(0, 0, defaultNumberOfDays),
+          defaultUserLimit,
+          Comparator.comparing(UserForTaskStatusDto::getDateLastActivity));
+      userForTaskStatusDtos.forEach(
+          userForTaskStatusDto -> userForTaskStatusDto.getTaskStatuses().forEach(taskStatus -> {
+            UserTask userTask = new UserTask();
+            userTask.setTaskName(taskStatus.getTaskName());
+            userTask.setGitName(userForTaskStatusDto.getGitName());
+            userTask.setTaskStatus(taskStatus.getTaskStatus());
+            userTask.setLastActivity(userForTaskStatusDto.getDateLastActivity());
+            userTask.setPullUrl(taskStatus.getPullUrl());
+            userTaskRepository.saveAndFlush(userTask);
+          }));
+    }
   }
 }

--- a/bot/src/main/java/com/community/tools/controller/GithubHookController.java
+++ b/bot/src/main/java/com/community/tools/controller/GithubHookController.java
@@ -26,9 +26,7 @@ public class GithubHookController {
   public void getHookData(@RequestBody String body) {
     log.info("Hit up the endpoint!");
     JSONObject eventJson = new JSONObject(body);
-    if (eventJson.has("action")) {
-      eventsProcessingService.processEvent(eventJson);
-    }
+    eventsProcessingService.processEvent(eventJson);
   }
 
 }

--- a/bot/src/main/java/com/community/tools/controller/GithubHookController.java
+++ b/bot/src/main/java/com/community/tools/controller/GithubHookController.java
@@ -24,7 +24,6 @@ public class GithubHookController {
    */
   @PostMapping
   public void getHookData(@RequestBody String body) {
-    log.info("Hit up the endpoint!");
     JSONObject eventJson = new JSONObject(body);
     eventsProcessingService.processEvent(eventJson);
   }

--- a/bot/src/main/java/com/community/tools/controller/GithubHookController.java
+++ b/bot/src/main/java/com/community/tools/controller/GithubHookController.java
@@ -1,8 +1,8 @@
 package com.community.tools.controller;
 
-import com.community.tools.service.github.GitHookDataService;
 import com.community.tools.service.github.event.GithubEventsProcessingService;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/gitHook")
+@Slf4j
 public class GithubHookController {
 
   private final GithubEventsProcessingService eventsProcessingService;
-  private final GitHookDataService gitHookDataService;
 
   /**
    * Method receive webhook data from GitHub.
@@ -24,8 +24,8 @@ public class GithubHookController {
    */
   @PostMapping
   public void getHookData(@RequestBody String body) {
+    log.info("Hit up the endpoint!");
     JSONObject eventJson = new JSONObject(body);
-    gitHookDataService.saveDataIntoDB(eventJson);
     if (eventJson.has("action")) {
       eventsProcessingService.processEvent(eventJson);
     }

--- a/bot/src/main/java/com/community/tools/controller/TaskStatusController.java
+++ b/bot/src/main/java/com/community/tools/controller/TaskStatusController.java
@@ -2,7 +2,7 @@ package com.community.tools.controller;
 
 import com.community.tools.dto.GithubUserDto;
 import com.community.tools.dto.UserForTaskStatusDto;
-import com.community.tools.service.TaskStatusService;
+import com.community.tools.service.TaskStatusServiceRestImpl;
 import java.time.Period;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -29,13 +29,13 @@ public class TaskStatusController {
   private final Map<String, Comparator<GithubUserDto>> comparators
       = new HashMap<>();
 
-  private final TaskStatusService taskStatusService;
+  private final TaskStatusServiceRestImpl taskStatusService;
 
   /**
    * Constructor.
    * @param taskStatusService - Inject taskStatusService
    */
-  public TaskStatusController(TaskStatusService taskStatusService) {
+  public TaskStatusController(TaskStatusServiceRestImpl taskStatusService) {
     this.taskStatusService = taskStatusService;
     comparators.put("DESC",
         Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());

--- a/bot/src/main/java/com/community/tools/controller/TaskStatusController.java
+++ b/bot/src/main/java/com/community/tools/controller/TaskStatusController.java
@@ -1,6 +1,5 @@
 package com.community.tools.controller;
 
-import com.community.tools.dto.GithubUserDto;
 import com.community.tools.dto.UserForTaskStatusDto;
 import com.community.tools.service.TaskStatusServiceRestImpl;
 import java.time.Period;
@@ -26,28 +25,30 @@ public class TaskStatusController {
   private Integer defaultNumberOfDays;
   @Value("${defaultRowLimit}")
   private Integer defaultUserLimit;
-  private final Map<String, Comparator<GithubUserDto>> comparators
+  private final Map<String, Comparator<UserForTaskStatusDto>> comparators
       = new HashMap<>();
 
   private final TaskStatusServiceRestImpl taskStatusService;
 
   /**
    * Constructor.
+   *
    * @param taskStatusService - Inject taskStatusService
    */
   public TaskStatusController(TaskStatusServiceRestImpl taskStatusService) {
     this.taskStatusService = taskStatusService;
     comparators.put("DESC",
-        Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());
+        Comparator.comparingInt(UserForTaskStatusDto::getCompletedTasks).reversed());
     comparators.put("ASC",
-        Comparator.comparingInt(GithubUserDto::getCompletedTasks));
+        Comparator.comparingInt(UserForTaskStatusDto::getCompletedTasks));
   }
 
   /**
    * Endpoint for task status service.
+   *
    * @param limit - limit of users for view.
-   * @param days - period of days fow view.
-   * @param sort - sort order (DESC, ASC).
+   * @param days  - period of days fow view.
+   * @param sort  - sort order (DESC, ASC).
    * @return - return list of DTO.
    */
   @GetMapping("/taskStatus/getStatuses")
@@ -56,9 +57,9 @@ public class TaskStatusController {
       @RequestParam(required = false) Optional<Integer> days,
       @RequestParam(required = false) Optional<String> sort) {
 
-    Comparator<GithubUserDto> comparator = comparators.getOrDefault(
+    Comparator<UserForTaskStatusDto> comparator = comparators.getOrDefault(
         sort.orElse("DESC").toUpperCase(),
-        Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());
+        Comparator.comparingInt(UserForTaskStatusDto::getCompletedTasks).reversed());
 
     return new ResponseEntity<>(
         taskStatusService.getTaskStatuses(
@@ -69,6 +70,7 @@ public class TaskStatusController {
 
   /**
    * Endpoint for receiving task names.
+   *
    * @return - set of names.
    */
   @GetMapping("/taskStatus/getTasks")

--- a/bot/src/main/java/com/community/tools/model/stats/UserTask.java
+++ b/bot/src/main/java/com/community/tools/model/stats/UserTask.java
@@ -1,0 +1,25 @@
+package com.community.tools.model.stats;
+
+import java.time.LocalDate;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_tasks")
+@IdClass(UserTaskId.class)
+@Getter
+@Setter
+public class UserTask {
+
+  @Id
+  private String gitName;
+  @Id
+  private String taskName;
+  private LocalDate lastActivity;
+  private String pullUrl;
+  private String taskStatus;
+}

--- a/bot/src/main/java/com/community/tools/model/stats/UserTaskId.java
+++ b/bot/src/main/java/com/community/tools/model/stats/UserTaskId.java
@@ -3,9 +3,11 @@ package com.community.tools.model.stats;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @EqualsAndHashCode
+@NoArgsConstructor
 public class UserTaskId implements Serializable {
 
   private String gitName;

--- a/bot/src/main/java/com/community/tools/model/stats/UserTaskId.java
+++ b/bot/src/main/java/com/community/tools/model/stats/UserTaskId.java
@@ -1,0 +1,13 @@
+package com.community.tools.model.stats;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+public class UserTaskId implements Serializable {
+
+  private String gitName;
+  private String taskName;
+}

--- a/bot/src/main/java/com/community/tools/repository/stats/UserTaskRepository.java
+++ b/bot/src/main/java/com/community/tools/repository/stats/UserTaskRepository.java
@@ -1,0 +1,11 @@
+package com.community.tools.repository.stats;
+
+import com.community.tools.model.stats.UserTask;
+import com.community.tools.model.stats.UserTaskId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserTaskRepository extends JpaRepository<UserTask, UserTaskId> {
+
+}

--- a/bot/src/main/java/com/community/tools/repository/stats/UserTaskRepository.java
+++ b/bot/src/main/java/com/community/tools/repository/stats/UserTaskRepository.java
@@ -2,10 +2,13 @@ package com.community.tools.repository.stats;
 
 import com.community.tools.model.stats.UserTask;
 import com.community.tools.model.stats.UserTaskId;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserTaskRepository extends JpaRepository<UserTask, UserTaskId> {
 
+  List<UserTask> findUserTasksByLastActivityAfter(LocalDate earliestActivity);
 }

--- a/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
+++ b/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -35,17 +36,21 @@ public class StatisticsServiceImpl implements StatisticService {
   @Value("${hallOfFameChannel}")
   private String hallOfFameChannel;
   private final Map<String, Comparator<GithubUserDto>> comparators
-          = new HashMap<>();
+      = new HashMap<>();
   private final String[] tableHeadTasks = {"Intro", "Generics", "GameOfLife", "GC"};
-  @Autowired
-  private DiscordService discordService;
-  @Autowired
-  private TaskStatusService taskStatusService;
+  private final DiscordService discordService;
+  private final TaskStatusService taskStatusService;
+
+  public StatisticsServiceImpl(DiscordService discordService,
+      @Qualifier("taskStatusServiceRest") TaskStatusService taskStatusService) {
+    this.discordService = discordService;
+    this.taskStatusService = taskStatusService;
+  }
 
 
   /**
-   * Generates and sends daily statistics to the Discord channel using the provided data.
-   * The statistics include information about completed tasks and their status.
+   * Generates and sends daily statistics to the Discord channel using the provided data. The
+   * statistics include information about completed tasks and their status.
    *
    * @Scheduled annotation specifies the schedule for executing this method.
    */
@@ -64,40 +69,40 @@ public class StatisticsServiceImpl implements StatisticService {
       int toIndex = Math.min(i + userRowsLimit, statisticsList.size());
 
       sendTextMessageToDiscord(createMonoText(createTableBody(statisticsList.subList(i, toIndex),
-              firstColLength, taskNames)));
+          firstColLength, taskNames)));
     }
   }
 
   private void createStatisticsTitle() {
     String tableTitle = "Daily statistics for "
-            + getCurrentFormattedDate("Europe/Kiev");
+        + getCurrentFormattedDate("Europe/Kiev");
     sendTextMessageToDiscord(createH2Text(tableTitle));
   }
 
   private String createTableLegend() {
     return "\n`:white_check_mark:` - DONE, `:red_square:` - DENIED, "
-            + "`:yellow_square:` - IN PROGRESS, `:white_large_square:` - UNDEFINED\n\n\n\n";
+        + "`:yellow_square:` - IN PROGRESS, `:white_large_square:` - UNDEFINED\n\n\n\n";
   }
 
   private List<UserForTaskStatusDto> getStatisticsList() {
     Comparator<GithubUserDto> comparator = comparators.getOrDefault(
-            "DESC".toUpperCase(),
-            Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());
+        "DESC".toUpperCase(),
+        Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());
 
     return taskStatusService.getTaskStatuses(
-            Period.ofDays(defaultNumberOfDays),
-            defaultUserLimit,
-            comparator);
+        Period.ofDays(defaultNumberOfDays),
+        defaultUserLimit,
+        comparator);
   }
 
   private int getMaxColLength(List<UserForTaskStatusDto> userStatusDtoList) {
     return userStatusDtoList.stream()
-            .mapToInt(userStatusDto -> {
-              String userName = userStatusDto.getGitName();
-              return userName != null ? userName.length() : 0;
-            })
-            .max()
-            .orElse(0);
+        .mapToInt(userStatusDto -> {
+          String userName = userStatusDto.getGitName();
+          return userName != null ? userName.length() : 0;
+        })
+        .max()
+        .orElse(0);
   }
 
   private String createTableHead(int firstColLength) {
@@ -107,16 +112,15 @@ public class StatisticsServiceImpl implements StatisticService {
 
     tableHead.append(createTableLegend());
 
-
     tableHead.append(headFirstCol)
-            .append(StringUtils.repeat(" ",
-                    firstColLength - headFirstCol.length()))
-            .append("  ")
-            .append(getVerticalSeparator());
+        .append(StringUtils.repeat(" ",
+            firstColLength - headFirstCol.length()))
+        .append("  ")
+        .append(getVerticalSeparator());
 
     for (int i = 0; i < tableHeadTasks.length; i++) {
       tableHead.append(tableHeadTasks[i])
-              .append("  ");
+          .append("  ");
       if (i != tableHeadTasks.length - 1) {
         tableHead.append(getVerticalSeparator());
       } else {
@@ -129,15 +133,15 @@ public class StatisticsServiceImpl implements StatisticService {
   }
 
   private String createTableBody(List<UserForTaskStatusDto> userPartList,
-                                 int firstColLength, String[] taskNames) {
+      int firstColLength, String[] taskNames) {
     StringBuilder tableBody = new StringBuilder();
 
     for (UserForTaskStatusDto userData : userPartList) {
       String userName = userData.getGitName();
       tableBody.append(userName)
-              .append(createDiscordLink(createGitHubLink(userName)))
-              .append(StringUtils.repeat(" ", firstColLength - userName.length()))
-              .append(getVerticalSeparator());
+          .append(createDiscordLink(createGitHubLink(userName)))
+          .append(StringUtils.repeat(" ", firstColLength - userName.length()))
+          .append(getVerticalSeparator());
 
       for (int i = 0; i < taskNames.length; i++) {
         String label = getTaskSmileStatus(userData.getTaskStatuses(), taskNames[i]);
@@ -150,7 +154,7 @@ public class StatisticsServiceImpl implements StatisticService {
         }
 
         tableBody.append(StringUtils.repeat(" ",
-                tableHeadTasks[i].length() - 3));
+            tableHeadTasks[i].length() - 3));
 
         if (i != taskNames.length - 1) {
           tableBody.append(getVerticalSeparator());
@@ -223,11 +227,11 @@ public class StatisticsServiceImpl implements StatisticService {
   }
 
   private String getTaskSmileStatus(List<TaskNameAndStatus> taskNameAndStatuses,
-                                    String taskName) {
+      String taskName) {
     String status = taskNameAndStatuses.stream()
-            .filter(task -> taskName.equals(task.getTaskName()))
-            .map(TaskNameAndStatus::getTaskStatus)
-            .findFirst().orElse("undefined");
+        .filter(task -> taskName.equals(task.getTaskName()))
+        .map(TaskNameAndStatus::getTaskStatus)
+        .findFirst().orElse("undefined");
 
     return TaskStatus.getEmojiByDescription(status);
   }

--- a/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
+++ b/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
@@ -35,12 +35,15 @@ public class StatisticsServiceImpl implements StatisticService {
       = new HashMap<>();
   private final String[] tableHeadTasks = {"Intro", "Generics", "GameOfLife", "GC"};
   private final DiscordService discordService;
-  private final TaskStatusService taskStatusService;
+  private final TaskStatusService taskStatusServiceHooks;
 
+  /**
+   * Required args constructor, used to inject the necessary dependencies into the Service.
+   */
   public StatisticsServiceImpl(DiscordService discordService,
-      @Qualifier("taskStatusServiceRest") TaskStatusService taskStatusService) {
+      @Qualifier("taskStatusServiceHooks") TaskStatusService taskStatusServiceHooks) {
     this.discordService = discordService;
-    this.taskStatusService = taskStatusService;
+    this.taskStatusServiceHooks = taskStatusServiceHooks;
   }
 
 
@@ -85,7 +88,7 @@ public class StatisticsServiceImpl implements StatisticService {
         "DESC".toUpperCase(),
         Comparator.comparingInt(UserForTaskStatusDto::getCompletedTasks).reversed());
 
-    return taskStatusService.getTaskStatuses(
+    return taskStatusServiceHooks.getTaskStatuses(
         Period.ofDays(defaultNumberOfDays),
         defaultUserLimit,
         comparator);

--- a/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
+++ b/bot/src/main/java/com/community/tools/service/StatisticsServiceImpl.java
@@ -1,11 +1,9 @@
 package com.community.tools.service;
 
 import com.community.tools.discord.DiscordService;
-import com.community.tools.dto.GithubUserDto;
 import com.community.tools.dto.UserForTaskStatusDto;
 import com.community.tools.model.TaskNameAndStatus;
 import com.community.tools.model.TaskStatus;
-
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
@@ -14,10 +12,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,7 +31,7 @@ public class StatisticsServiceImpl implements StatisticService {
   private String originalTaskNames;
   @Value("${hallOfFameChannel}")
   private String hallOfFameChannel;
-  private final Map<String, Comparator<GithubUserDto>> comparators
+  private final Map<String, Comparator<UserForTaskStatusDto>> comparators
       = new HashMap<>();
   private final String[] tableHeadTasks = {"Intro", "Generics", "GameOfLife", "GC"};
   private final DiscordService discordService;
@@ -85,9 +81,9 @@ public class StatisticsServiceImpl implements StatisticService {
   }
 
   private List<UserForTaskStatusDto> getStatisticsList() {
-    Comparator<GithubUserDto> comparator = comparators.getOrDefault(
+    Comparator<UserForTaskStatusDto> comparator = comparators.getOrDefault(
         "DESC".toUpperCase(),
-        Comparator.comparingInt(GithubUserDto::getCompletedTasks).reversed());
+        Comparator.comparingInt(UserForTaskStatusDto::getCompletedTasks).reversed());
 
     return taskStatusService.getTaskStatuses(
         Period.ofDays(defaultNumberOfDays),

--- a/bot/src/main/java/com/community/tools/service/TaskStatusService.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusService.java
@@ -1,6 +1,5 @@
 package com.community.tools.service;
 
-import com.community.tools.dto.GithubUserDto;
 import com.community.tools.dto.UserForTaskStatusDto;
 import java.time.Period;
 import java.util.Comparator;
@@ -17,6 +16,6 @@ public interface TaskStatusService {
    * @return - return list of DTO.
    */
   List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
-      Comparator<GithubUserDto> comparator);
+      Comparator<UserForTaskStatusDto> comparator);
 
 }

--- a/bot/src/main/java/com/community/tools/service/TaskStatusService.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusService.java
@@ -1,172 +1,22 @@
 package com.community.tools.service;
 
-import com.community.tools.dto.GithubRepositoryDto;
 import com.community.tools.dto.GithubUserDto;
 import com.community.tools.dto.UserForTaskStatusDto;
-import com.community.tools.model.TaskNameAndStatus;
-import com.community.tools.model.TaskStatus;
-import com.community.tools.service.github.ClassroomService;
-
-import java.time.LocalDate;
 import java.time.Period;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
-@Slf4j
-@Service
-public class TaskStatusService {
-
-  private final ClassroomService classroomService;
-
-  public TaskStatusService(ClassroomService classroomService) {
-    this.classroomService = classroomService;
-  }
+public interface TaskStatusService {
 
   /**
    * Service for sorting, limiting and creating DTO.
-   * @param limit - limit of users for view.
-   * @param period - period of days fow view.
+   *
+   * @param limit      - limit of users for view.
+   * @param period     - period of days fow view.
    * @param comparator - sort order (DESC, ASC).
    * @return - return list of DTO.
    */
-  public List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
-      Comparator<GithubUserDto> comparator) {
-    log.info("running with period = {}, comparator = {}, limit = {}", period, comparator, limit);
-    return classroomService.getAllActiveUsers(period).stream()
-        .filter(this::isActiveUser)
-        .sorted(comparator)
-        .limit(limit)
-        .map(
-            githubUserDto ->
-                new UserForTaskStatusDto(
-                    githubUserDto.getGitName(),
-                    githubUserDto.getLastCommit(),
-                    githubUserDto.getCompletedTasks(),
-                    getAllTaskNameAndStatusesForEachUser(githubUserDto)))
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Getting List of task, and status of this task, for each user,
-   *  based on labels.
-   * @param user - user DTO.
-   * @return - list of task, and status of this task, for each user.
-   */
-  private List<TaskNameAndStatus> getAllTaskNameAndStatusesForEachUser(GithubUserDto user) {
-    return user.getRepositories().stream().map(repo -> {
-      String currentStatus;
-      if (repo.getLabels().size() > 1) {
-        currentStatus = TaskStatus.UNDEFINED.getDescription();
-      } else if (repo.getLabels().isEmpty()) {
-        currentStatus = TaskStatus.NEW.getDescription();
-      } else {
-        currentStatus = repo.getLabels().get(0);
-      }
-      return new TaskNameAndStatus(repo.getTaskName(), repo.getPullUrl(),
-              currentStatus);
-    }).collect(Collectors.toList());
-  }
-
-  /**
-   * Checks if the user is active.
-   *
-   * @param user The user for whom the check is performed.
-   * @return true if the user is active, otherwise false.
-   */
-  private boolean isActiveUser(GithubUserDto user) {
-    LocalDate lastCommitDate = user.getLastCommit();
-    boolean allTasksApproved = areAllUserTasksApproved(user);
-
-    if (lastCommitDate == null || daysBetween(lastCommitDate, LocalDate.now()) >= 7) {
-      return false;
-    }
-
-    return allTasksApproved;
-  }
-
-  /**
-   * Checks if all user tasks are approved and have reviews.
-   *
-   * @param user The user for whom the check is performed.
-   * @return true if all tasks are approved and have reviews, otherwise false.
-   */
-  private boolean areAllUserTasksApproved(GithubUserDto user) {
-    List<TaskNameAndStatus> taskStatuses = getAllTaskNameAndStatusesForEachUser(user);
-
-    for (TaskNameAndStatus taskStatus : taskStatuses) {
-      String status = taskStatus.getTaskStatus();
-      if (status.equals(TaskStatus.UNDEFINED.getDescription())) {
-        return false;
-      }
-
-      if (!hasReviews(taskStatus, user)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Checks if a task has reviews.
-   *
-   * @param taskStatus The task and its status.
-   * @param user The user for whom the check is performed.
-   * @return true if the task has reviews, otherwise false.
-   */
-  private boolean hasReviews(TaskNameAndStatus taskStatus, GithubUserDto user) {
-    for (GithubRepositoryDto repository : user.getRepositories()) {
-      if (isMatchingTask(repository, taskStatus)) {
-        if (hasReviewLabel(repository)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Checks if a task matches a repository.
-   *
-   * @param repository The repository to check.
-   * @param taskStatus The task and its status.
-   * @return true if the task matches the repository, otherwise false.
-   */
-  private boolean isMatchingTask(GithubRepositoryDto repository, TaskNameAndStatus taskStatus) {
-    return repository.getTaskName().equals(taskStatus.getTaskName());
-  }
-
-  /**
-   * Checks if a GitHub repository has a label containing "failure".
-   *
-   * @param repository The GitHub repository to check for labels.
-   * @return true if the repository has a label not containing "failure", otherwise false.
-   */
-  private boolean hasReviewLabel(GithubRepositoryDto repository) {
-    List<String> labels = repository.getLabels();
-    if (labels != null && !labels.isEmpty()) {
-      for (String label : labels) {
-        if (!label.contains("failure")) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Calculates the number of days between two dates.
-   *
-   * @param startDate The start date.
-   * @param endDate The end date.
-   * @return The number of days between the two dates.
-   */
-  private long daysBetween(LocalDate startDate, LocalDate endDate) {
-    return ChronoUnit.DAYS.between(startDate, endDate);
-  }
+  List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
+      Comparator<GithubUserDto> comparator);
 
 }

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
@@ -1,15 +1,67 @@
 package com.community.tools.service;
 
 import com.community.tools.dto.UserForTaskStatusDto;
+import com.community.tools.model.TaskNameAndStatus;
+import com.community.tools.model.TaskStatus;
+import com.community.tools.model.stats.UserTask;
+import com.community.tools.repository.stats.UserTaskRepository;
+import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
 
+@Slf4j
+@Service("taskStatusServiceHooks")
+@Profile("discord")
 public class TaskStatusServiceHooksImpl implements TaskStatusService {
+
+  private final UserTaskRepository userTaskRepository;
+
+  public TaskStatusServiceHooksImpl(UserTaskRepository userTaskRepository) {
+    this.userTaskRepository = userTaskRepository;
+  }
 
   @Override
   public List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
       Comparator<UserForTaskStatusDto> comparator) {
-    return null;
+    LocalDate startDate = LocalDate.ofEpochDay(LocalDate
+        .now()
+        .minus(period).toEpochDay());
+    return userTaskRepository
+        .findUserTasksByLastActivityAfter(startDate)
+        .stream()
+        .collect(Collectors.groupingBy(UserTask::getGitName))
+        .entrySet()
+        .stream()
+        .map(entry -> {
+          List<TaskNameAndStatus> taskNamesAndStatuses = new ArrayList<>();
+          entry.getValue().forEach(
+              task -> taskNamesAndStatuses.add(
+                  new TaskNameAndStatus(task.getTaskName(), task.getPullUrl(),
+                      task.getTaskStatus())));
+
+          final int completedTasksCount = (int) taskNamesAndStatuses.stream()
+              .filter(it -> it.getTaskStatus().equals(
+                  TaskStatus.DONE.getDescription())).count();
+
+          /* This is supposed to throw NoSuchElementException
+          in case it cannot find lastActivity for gitName
+          because it is PPK in db, therefore at least one such record MUST exist,
+          if it does not, something went terribly wrong,
+          there is no point in trying to recover.
+           */
+          final LocalDate lastActive = entry.getValue().stream().max(
+              Comparator.comparing(UserTask::getLastActivity)).get().getLastActivity();
+          return new UserForTaskStatusDto(entry.getKey(),
+              lastActive, completedTasksCount, taskNamesAndStatuses);
+        })
+        .sorted(comparator)
+        .limit(limit)
+        .collect(Collectors.toList());
   }
 }

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
@@ -1,0 +1,15 @@
+package com.community.tools.service;
+
+import com.community.tools.dto.UserForTaskStatusDto;
+import java.time.Period;
+import java.util.Comparator;
+import java.util.List;
+
+public class TaskStatusServiceHooksImpl implements TaskStatusService {
+
+  @Override
+  public List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
+      Comparator<UserForTaskStatusDto> comparator) {
+    return null;
+  }
+}

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceHooksImpl.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,8 @@ import org.springframework.stereotype.Service;
 public class TaskStatusServiceHooksImpl implements TaskStatusService {
 
   private final UserTaskRepository userTaskRepository;
+  @Value("${tasksForUsers}")
+  private String originalTaskNames;
 
   public TaskStatusServiceHooksImpl(UserTaskRepository userTaskRepository) {
     this.userTaskRepository = userTaskRepository;
@@ -46,6 +49,7 @@ public class TaskStatusServiceHooksImpl implements TaskStatusService {
                       task.getTaskStatus())));
 
           final int completedTasksCount = (int) taskNamesAndStatuses.stream()
+              .filter(it -> originalTaskNames.contains(it.getTaskName()))
               .filter(it -> it.getTaskStatus().equals(
                   TaskStatus.DONE.getDescription())).count();
 

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
@@ -38,7 +38,6 @@ public class TaskStatusServiceRestImpl implements TaskStatusService {
       Comparator<UserForTaskStatusDto> comparator) {
     log.info("running with period = {}, comparator = {}, limit = {}", period, comparator, limit);
     return classroomService.getAllActiveUsers(period).stream()
-        .filter(this::isActiveUser)
         .limit(limit)
         .map(
             githubUserDto ->

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
@@ -35,11 +35,10 @@ public class TaskStatusServiceRestImpl implements TaskStatusService {
    * @return - return list of DTO.
    */
   public List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
-      Comparator<GithubUserDto> comparator) {
+      Comparator<UserForTaskStatusDto> comparator) {
     log.info("running with period = {}, comparator = {}, limit = {}", period, comparator, limit);
     return classroomService.getAllActiveUsers(period).stream()
         .filter(this::isActiveUser)
-        .sorted(comparator)
         .limit(limit)
         .map(
             githubUserDto ->
@@ -48,6 +47,7 @@ public class TaskStatusServiceRestImpl implements TaskStatusService {
                     githubUserDto.getLastCommit(),
                     githubUserDto.getCompletedTasks(),
                     getAllTaskNameAndStatusesForEachUser(githubUserDto)))
+        .sorted(comparator)
         .collect(Collectors.toList());
   }
 

--- a/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
+++ b/bot/src/main/java/com/community/tools/service/TaskStatusServiceRestImpl.java
@@ -1,0 +1,173 @@
+package com.community.tools.service;
+
+import com.community.tools.dto.GithubRepositoryDto;
+import com.community.tools.dto.GithubUserDto;
+import com.community.tools.dto.UserForTaskStatusDto;
+import com.community.tools.model.TaskNameAndStatus;
+import com.community.tools.model.TaskStatus;
+import com.community.tools.service.github.ClassroomService;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("taskStatusServiceRest")
+public class TaskStatusServiceRestImpl implements TaskStatusService {
+
+  private final ClassroomService classroomService;
+
+  public TaskStatusServiceRestImpl(ClassroomService classroomService) {
+    this.classroomService = classroomService;
+  }
+
+  /**
+   * Service for sorting, limiting and creating DTO.
+   *
+   * @param limit      - limit of users for view.
+   * @param period     - period of days fow view.
+   * @param comparator - sort order (DESC, ASC).
+   * @return - return list of DTO.
+   */
+  public List<UserForTaskStatusDto> getTaskStatuses(Period period, Integer limit,
+      Comparator<GithubUserDto> comparator) {
+    log.info("running with period = {}, comparator = {}, limit = {}", period, comparator, limit);
+    return classroomService.getAllActiveUsers(period).stream()
+        .filter(this::isActiveUser)
+        .sorted(comparator)
+        .limit(limit)
+        .map(
+            githubUserDto ->
+                new UserForTaskStatusDto(
+                    githubUserDto.getGitName(),
+                    githubUserDto.getLastCommit(),
+                    githubUserDto.getCompletedTasks(),
+                    getAllTaskNameAndStatusesForEachUser(githubUserDto)))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Getting List of task, and status of this task, for each user, based on labels.
+   *
+   * @param user - user DTO.
+   * @return - list of task, and status of this task, for each user.
+   */
+  private List<TaskNameAndStatus> getAllTaskNameAndStatusesForEachUser(GithubUserDto user) {
+    return user.getRepositories().stream().map(repo -> {
+      String currentStatus;
+      if (repo.getLabels().size() > 1) {
+        currentStatus = TaskStatus.UNDEFINED.getDescription();
+      } else if (repo.getLabels().isEmpty()) {
+        currentStatus = TaskStatus.NEW.getDescription();
+      } else {
+        currentStatus = repo.getLabels().get(0);
+      }
+      return new TaskNameAndStatus(repo.getTaskName(), repo.getPullUrl(),
+          currentStatus);
+    }).collect(Collectors.toList());
+  }
+
+  /**
+   * Checks if the user is active.
+   *
+   * @param user The user for whom the check is performed.
+   * @return true if the user is active, otherwise false.
+   */
+  private boolean isActiveUser(GithubUserDto user) {
+    LocalDate lastCommitDate = user.getLastCommit();
+    boolean allTasksApproved = areAllUserTasksApproved(user);
+
+    if (lastCommitDate == null || daysBetween(lastCommitDate, LocalDate.now()) >= 7) {
+      return false;
+    }
+
+    return allTasksApproved;
+  }
+
+  /**
+   * Checks if all user tasks are approved and have reviews.
+   *
+   * @param user The user for whom the check is performed.
+   * @return true if all tasks are approved and have reviews, otherwise false.
+   */
+  private boolean areAllUserTasksApproved(GithubUserDto user) {
+    List<TaskNameAndStatus> taskStatuses = getAllTaskNameAndStatusesForEachUser(user);
+
+    for (TaskNameAndStatus taskStatus : taskStatuses) {
+      String status = taskStatus.getTaskStatus();
+      if (status.equals(TaskStatus.UNDEFINED.getDescription())) {
+        return false;
+      }
+
+      if (!hasReviews(taskStatus, user)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Checks if a task has reviews.
+   *
+   * @param taskStatus The task and its status.
+   * @param user       The user for whom the check is performed.
+   * @return true if the task has reviews, otherwise false.
+   */
+  private boolean hasReviews(TaskNameAndStatus taskStatus, GithubUserDto user) {
+    for (GithubRepositoryDto repository : user.getRepositories()) {
+      if (isMatchingTask(repository, taskStatus)) {
+        if (hasReviewLabel(repository)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Checks if a task matches a repository.
+   *
+   * @param repository The repository to check.
+   * @param taskStatus The task and its status.
+   * @return true if the task matches the repository, otherwise false.
+   */
+  private boolean isMatchingTask(GithubRepositoryDto repository, TaskNameAndStatus taskStatus) {
+    return repository.getTaskName().equals(taskStatus.getTaskName());
+  }
+
+  /**
+   * Checks if a GitHub repository has a label containing "failure".
+   *
+   * @param repository The GitHub repository to check for labels.
+   * @return true if the repository has a label not containing "failure", otherwise false.
+   */
+  private boolean hasReviewLabel(GithubRepositoryDto repository) {
+    List<String> labels = repository.getLabels();
+    if (labels != null && !labels.isEmpty()) {
+      for (String label : labels) {
+        if (!label.contains("failure")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Calculates the number of days between two dates.
+   *
+   * @param startDate The start date.
+   * @param endDate   The end date.
+   * @return The number of days between the two dates.
+   */
+  private long daysBetween(LocalDate startDate, LocalDate endDate) {
+    return ChronoUnit.DAYS.between(startDate, endDate);
+  }
+
+}

--- a/bot/src/main/java/com/community/tools/service/github/ClassroomServiceImpl.java
+++ b/bot/src/main/java/com/community/tools/service/github/ClassroomServiceImpl.java
@@ -164,7 +164,7 @@ public class ClassroomServiceImpl implements ClassroomService {
 
     return allUserRepositories
             .entrySet()
-            .stream()
+            .parallelStream()
             .map(entry -> buildGithubUserDto(entry.getKey(), entry.getValue()))
             .collect(Collectors.toList());
   }
@@ -174,7 +174,7 @@ public class ClassroomServiceImpl implements ClassroomService {
     return organization
             .getRepositories()
             .entrySet()
-            .stream()
+            .parallelStream()
             .filter(entry -> repositoryNameService.isPrefixedWithTaskName(entry.getKey()))
             .map(entry -> {
               GHRepository repository = entry.getValue();

--- a/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
@@ -1,26 +1,78 @@
 package com.community.tools.service.github.event.stats;
 
+import com.community.tools.model.TaskStatus;
+import com.community.tools.model.stats.UserTask;
+import com.community.tools.model.stats.UserTaskId;
+import com.community.tools.repository.stats.UserTaskRepository;
 import com.community.tools.service.github.event.GithubEventHandler;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("discord")
 public class GithubWorkflowRunEventHandler implements GithubEventHandler {
+
+  private final UserTaskRepository userTaskRepository;
 
   @Override
   // repository->name - task name
   // workflow_run->actor->login - user git name
   // action key should be "completed"
   // pull request number pull_requests->(list of objects, get(0), form into json)->number
+  // workflow_run->conclusion - result of the workflow
   public void handleEvent(JSONObject eventJson) {
-    if (eventJson.getString("action").equals("completed")) {
-      log.info(((JSONObject) eventJson.get("repository")).getString("name"));
-      log.info(((JSONObject) eventJson.get("repository")).getString("full_name"));
-      log.info(((JSONObject) ((JSONObject) eventJson.get("workflow_run")).get("actor")).getString(
-          "login"));
-      int pullId = ((JSONObject) ((JSONObject) eventJson.get("workflow_run")).getJSONArray(
-          "pull_requests").get(0)).getInt("number");
-      log.info(pullId + "");
+    if (eventJson.has("action") && eventJson.getString("action").equals("completed")) {
+      parseAndSaveWorkflowRun(eventJson);
     }
+  }
+
+  private void parseAndSaveWorkflowRun(JSONObject eventJson) {
+    JSONObject repo = (JSONObject) eventJson.get("repository");
+    JSONObject workflowRun = (JSONObject) eventJson.get("workflow_run");
+    String gitName = ((JSONObject) workflowRun.get("actor")).getString(
+        "login");
+    String taskName = getTaskName(repo.getString("name"), gitName);
+    String repoFullName = repo.getString("full_name");
+    String conclusion = workflowRun.getString("conclusion");
+    int pullId = ((JSONObject) workflowRun.getJSONArray(
+        "pull_requests").get(0)).getInt("number");
+    Optional<UserTask> existingUserTaskRecord = userTaskRepository.findById(
+        new UserTaskId(gitName, taskName));
+    UserTask record;
+    if (existingUserTaskRecord.isPresent()) {
+      record = existingUserTaskRecord.get();
+    } else {
+      record = new UserTask();
+      record.setGitName(gitName);
+      record.setPullUrl(formPullUrl(pullId, repoFullName));
+      record.setTaskName(taskName);
+    }
+    record.setLastActivity(LocalDate.now());
+    record.setPullUrl(formPullUrl(pullId, repoFullName));
+    if (conclusion.equals("success")) {
+      record.setTaskStatus(TaskStatus.READY_FOR_REVIEW.getDescription());
+    } else {
+      record.setTaskStatus(TaskStatus.FAILURE.getDescription());
+    }
+    userTaskRepository.saveAndFlush(record);
+  }
+
+  private static String formPullUrl(int pullNumber, String repoFullName) {
+    return "https://github.com/" + repoFullName + "pull/" + pullNumber;
+  }
+
+  private static String getTaskName(String repoName, String gitName) {
+    int gitNameIndex = repoName.indexOf("-" + gitName);
+    if (gitNameIndex != -1) {
+      return repoName.substring(0, gitNameIndex);
+    }
+    return repoName;
   }
 }

--- a/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
@@ -22,17 +22,20 @@ public class GithubWorkflowRunEventHandler implements GithubEventHandler {
   private final UserTaskRepository userTaskRepository;
 
   @Override
-  // repository->name - task name
-  // workflow_run->actor->login - user git name
-  // action key should be "completed"
-  // pull request number pull_requests->(list of objects, get(0), form into json)->number
-  // workflow_run->conclusion - result of the workflow
   public void handleEvent(JSONObject eventJson) {
     if (eventJson.has("action") && eventJson.getString("action").equals("completed")) {
       parseAndSaveWorkflowRun(eventJson);
     }
   }
 
+  /**
+   * Processes JSON data from GitHub workflow_run event, saves it to the configured database.
+   *
+   * @param eventJson - representation of the JSON data from GitHub workflow_run event
+   * @see <a
+   * href="https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run">GitHub docs
+   * about the event</a>
+   */
   private void parseAndSaveWorkflowRun(JSONObject eventJson) {
     JSONObject repo = (JSONObject) eventJson.get("repository");
     JSONObject workflowRun = (JSONObject) eventJson.get("workflow_run");
@@ -51,7 +54,6 @@ public class GithubWorkflowRunEventHandler implements GithubEventHandler {
     } else {
       record = new UserTask();
       record.setGitName(gitName);
-      record.setPullUrl(formPullUrl(pullId, repoFullName));
       record.setTaskName(taskName);
     }
     record.setLastActivity(LocalDate.now());

--- a/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
@@ -37,14 +37,14 @@ public class GithubWorkflowRunEventHandler implements GithubEventHandler {
    * about the event</a>
    */
   private void parseAndSaveWorkflowRun(JSONObject eventJson) {
-    JSONObject repo = (JSONObject) eventJson.get("repository");
-    JSONObject workflowRun = (JSONObject) eventJson.get("workflow_run");
-    String gitName = ((JSONObject) workflowRun.get("actor")).getString(
+    final JSONObject repo = (JSONObject) eventJson.get("repository");
+    final JSONObject workflowRun = (JSONObject) eventJson.get("workflow_run");
+    final String gitName = ((JSONObject) workflowRun.get("actor")).getString(
         "login");
-    String taskName = getTaskName(repo.getString("name"), gitName);
-    String repoFullName = repo.getString("full_name");
-    String conclusion = workflowRun.getString("conclusion");
-    int pullId = ((JSONObject) workflowRun.getJSONArray(
+    final String taskName = getTaskName(repo.getString("name"), gitName);
+    final String repoFullName = repo.getString("full_name");
+    final String conclusion = workflowRun.getString("conclusion");
+    final int pullId = ((JSONObject) workflowRun.getJSONArray(
         "pull_requests").get(0)).getInt("number");
     Optional<UserTask> existingUserTaskRecord = userTaskRepository.findById(
         new UserTaskId(gitName, taskName));

--- a/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/stats/GithubWorkflowRunEventHandler.java
@@ -1,0 +1,26 @@
+package com.community.tools.service.github.event.stats;
+
+import com.community.tools.service.github.event.GithubEventHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+
+@Slf4j
+public class GithubWorkflowRunEventHandler implements GithubEventHandler {
+
+  @Override
+  // repository->name - task name
+  // workflow_run->actor->login - user git name
+  // action key should be "completed"
+  // pull request number pull_requests->(list of objects, get(0), form into json)->number
+  public void handleEvent(JSONObject eventJson) {
+    if (eventJson.getString("action").equals("completed")) {
+      log.info(((JSONObject) eventJson.get("repository")).getString("name"));
+      log.info(((JSONObject) eventJson.get("repository")).getString("full_name"));
+      log.info(((JSONObject) ((JSONObject) eventJson.get("workflow_run")).get("actor")).getString(
+          "login"));
+      int pullId = ((JSONObject) ((JSONObject) eventJson.get("workflow_run")).getJSONArray(
+          "pull_requests").get(0)).getInt("number");
+      log.info(pullId + "");
+    }
+  }
+}


### PR DESCRIPTION
Перероблено архітектуру отримання даних про стан завдань користувачів, тепер маємо очікувати дані на гіт хук зараєстрований на отримання Workflow runs, для отримання ширшої інформації про зміни стану завданнь необхідно прослуховувати ще, щонайменше, pull_request_review, що поки не реалізовано, бо необхідно визначити моменти переходу завдання зі стану у стан.