### PR TITLE
fix workflow run relevancy check

### DIFF
--- a/bot/src/main/java/com/community/tools/service/github/event/GitHubHookEventService.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/GitHubHookEventService.java
@@ -215,9 +215,10 @@ public class GitHubHookEventService {
   }
 
   private boolean checkIfEventIsIrrelevant(JSONObject workflowRun, String taskName) {
-    if (!workflowRun.getString("head_branch").equals("feedback")) {
+    if (!workflowRun.getString("head_branch").equals("master")) {
       return true; /* we are only interested in processing changes GitHub Classroom automatically
-      adds to the pull request with head branch "feedback" */
+      adds to the pull request with head branch "master" into base branch "feedback", commits by
+      trainees should be made into master as by GitHub classroom instructions */
     }
     return !originalTaskNames.contains(taskName);
   }

--- a/bot/src/main/java/com/community/tools/service/github/event/GitHubHookEventService.java
+++ b/bot/src/main/java/com/community/tools/service/github/event/GitHubHookEventService.java
@@ -214,11 +214,15 @@ public class GitHubHookEventService {
     return Optional.empty();
   }
 
+  /**
+   * Determines whether we are not interested in processing this workflow run.
+   * We are only interested in processing changes GitHub Classroom automatically
+   * adds to the pull request with head branch "master" into base branch "feedback", commits by
+   * trainees should be made into master as by GitHub classroom instructions.
+   */
   private boolean checkIfEventIsIrrelevant(JSONObject workflowRun, String taskName) {
     if (!workflowRun.getString("head_branch").equals("master")) {
-      return true; /* we are only interested in processing changes GitHub Classroom automatically
-      adds to the pull request with head branch "master" into base branch "feedback", commits by
-      trainees should be made into master as by GitHub classroom instructions */
+      return true;
     }
     return !originalTaskNames.contains(taskName);
   }


### PR DESCRIPTION
Fixes a bug wich lead GitHubHookEventService to discard relevant workflow_run events because the expected head_branch was wrong.