### PR TITLE
Old user join handling. Handling /register when no username provided

### DIFF
--- a/bot/src/main/java/com/community/tools/model/Messages.java
+++ b/bot/src/main/java/com/community/tools/model/Messages.java
@@ -158,11 +158,14 @@ public class Messages {
           + "или в Discord (Dany Mruie#0342). Удачи!</pre>";
 
   public static final String WELCOME_MENTION =
-      "Greetings, %s! Use /register to complete registration";
+      "Greetings, %s! Use /register and provide your GitHub username to complete registration";
   public static final String GITHUB_ACCOUNT_NOT_FOUND =
       "GitHub username you provided is incorrect. Check it and try again.";
   public static final String REGISTRATION_COMPLETED =
       "Registration completed! Now you should see more channels available.";
-  public static final String USE_REGISTER_COMMAND = "Use /register to complete registration";
   public static final String USERNAME_UPDATED = "Username updated successfully!";
+  public static final String NOT_REGISTERED =
+      "You are not registered yet. Use /register and provide GitHub username";
+  public static final String CURRENT_USERNAME = "Your GitHub username is \"%s\". "
+      + "You can update it by calling /register and providing a username.";
 }


### PR DESCRIPTION
Now, when new user joins the guild, app checks if there is a record in DB and if it has GitHub username. If both requirements met, user is considered registered and doesn't need to go through registration process again. Otherwise, user must use /register command.

/register command has an option "username". It is not required, so user can use the command without it. If user is not registered (no GitHub username in DB), bot asks to use the command with the option. If user is registered, bot sends a message with current username, and gives instructions on how to update it if needed.