### PR TITLE
fixed bot spamming, updated /register and /stat

### DIFF
--- a/bot/src/main/java/com/community/tools/model/Messages.java
+++ b/bot/src/main/java/com/community/tools/model/Messages.java
@@ -159,6 +159,7 @@ public class Messages {
 
   public static final String WELCOME_MENTION =
       "Greetings, %s! Use /register and provide your GitHub username to complete registration";
+  public static final String WELCOME_OLD_MENTION = "Greetings, %s! Haven't seen you in a while.";
   public static final String GITHUB_ACCOUNT_NOT_FOUND =
       "GitHub username you provided is incorrect. Check it and try again.";
   public static final String REGISTRATION_COMPLETED =

--- a/bot/src/main/java/com/community/tools/service/MessageListener.java
+++ b/bot/src/main/java/com/community/tools/service/MessageListener.java
@@ -46,10 +46,10 @@ public class MessageListener implements EventListener {
     if (resetUser(userId, guildId)) {
       messageService.addRoleToUser(guildId, userId, newbieRoleName);
       messageService.sendMessageToConversation(welcomeChannelName,
-        String.format(Messages.WELCOME_MENTION, event.getUser().getAsMention()));
+          String.format(Messages.WELCOME_MENTION, event.getUser().getAsMention()));
     } else {
       messageService.sendMessageToConversation(welcomeChannelName,
-        String.format(Messages.WELCOME_OLD_MENTION, event.getUser().getAsMention()));
+          String.format(Messages.WELCOME_OLD_MENTION, event.getUser().getAsMention()));
     }
   }
 
@@ -67,6 +67,7 @@ public class MessageListener implements EventListener {
    * Receives and processes messages in guilds.
    * Currently, there is no reaction from bot, as sending default message for any event
    * leads to spamming.
+   *
    * @param event received event from Discord
    */
   @Override

--- a/bot/src/main/java/com/community/tools/service/MessageListener.java
+++ b/bot/src/main/java/com/community/tools/service/MessageListener.java
@@ -7,7 +7,6 @@ import com.community.tools.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
@@ -39,13 +38,19 @@ public class MessageListener implements EventListener {
 
   @Override
   public void memberJoin(GuildMemberJoinEvent event) {
+    if (event.getUser().isBot()) {
+      return;
+    }
     String userId = event.getUser().getId();
     String guildId = event.getGuild().getId();
     if (resetUser(userId, guildId)) {
       messageService.addRoleToUser(guildId, userId, newbieRoleName);
-    }
-    messageService.sendMessageToConversation(welcomeChannelName,
+      messageService.sendMessageToConversation(welcomeChannelName,
         String.format(Messages.WELCOME_MENTION, event.getUser().getAsMention()));
+    } else {
+      messageService.sendMessageToConversation(welcomeChannelName,
+        String.format(Messages.WELCOME_OLD_MENTION, event.getUser().getAsMention()));
+    }
   }
 
   @Override
@@ -58,12 +63,15 @@ public class MessageListener implements EventListener {
         .run(event);
   }
 
+  /**
+   * Receives and processes messages in guilds.
+   * Currently, there is no reaction from bot, as sending default message for any event
+   * leads to spamming.
+   * @param event received event from Discord
+   */
   @Override
   public void guildMessageReceived(GuildMessageReceivedEvent event) {
-    if (event.getMessage().getType() != MessageType.GUILD_MEMBER_JOIN) {
-      messageService.sendMessageToConversation(event.getChannel().getName(),
-          Messages.DEFAULT_MESSAGE);
-    }
+
   }
 
   @Override

--- a/bot/src/main/java/com/community/tools/service/discord/StatCommand.java
+++ b/bot/src/main/java/com/community/tools/service/discord/StatCommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 
@@ -14,6 +15,9 @@ import org.springframework.stereotype.Component;
 public class StatCommand extends Command {
 
   private final StatisticService statisticService;
+
+  @Value("${adminRole}")
+  private String adminRoleName;
 
   public StatCommand(StatisticService statisticService) {
     super(new CommandData("stat", "Receive stats"));
@@ -32,7 +36,7 @@ public class StatCommand extends Command {
       return;
     }
     List<Role> userRoles = member.getRoles();
-    boolean isAdmin = userRoles.stream().anyMatch(role -> role.getName().equals("admin"));
+    boolean isAdmin = userRoles.stream().anyMatch(role -> role.getName().equals(adminRoleName));
 
     if (isAdmin) {
       command.reply("Статистика генерируется.Пожалуйста подождите...").queue();

--- a/bot/src/main/resources/application.properties
+++ b/bot/src/main/resources/application.properties
@@ -53,6 +53,7 @@ hallOfFameChannel = hall-of-fame
 generalInformationChannel = test_3
 welcomeChannel = welcome
 newbieRole = newbie
+adminRole = Admin
 urlServer = ${URL_SERVER}
 
 testModeSwitcher = false


### PR DESCRIPTION
Bot used to answer EVERY message it received in guild. Now this logic is deleted.

/stat used "admin" role to check if user has privilege to use the command. Now the role name is specified in .properties, so StatCommand uses the property, and not a hardcoded string.

/register could be used only if we had stored user in DB. Now, if user's entity is missing, it will be automatically created when he passes the registration. (By default, it is still created when user joins a guild).